### PR TITLE
bridge contract error triage

### DIFF
--- a/bridge/contract/Cargo.toml
+++ b/bridge/contract/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-casperlabs-contract = "0.5.1"
-casperlabs-types = "0.5.1"
+casperlabs-contract = "=0.5.0"
+casperlabs-types = "=0.5.0"
 obi = { version = "0.0.1" }
 hex = "0.4.2"
 tiny-keccak = { version = "2.0", features = ["keccak"] }

--- a/bridge/contract/src/api.rs
+++ b/bridge/contract/src/api.rs
@@ -1,12 +1,12 @@
 use casperlabs_contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use casperlabs_types::{account::PublicKey, bytesrepr::FromBytes, CLTyped, ContractRef, U512};
+use casperlabs_types::{bytesrepr::FromBytes, CLTyped};
 
 use crate::error::Error;
 
 pub const RELAY_AND_VERIFY: &str = "relay_and_verify";
 
 pub enum Api {
-    RELAY_AND_VERIFY(Vec<u8>),
+    RelayAndVerify(Vec<u8>),
 }
 
 fn get_arg<T: CLTyped + FromBytes>(i: u32) -> T {
@@ -21,7 +21,7 @@ impl Api {
         match method_name.as_str() {
             RELAY_AND_VERIFY => {
                 let proof: Vec<u8> = get_arg(1);
-                Api::RELAY_AND_VERIFY(proof)
+                Api::RelayAndVerify(proof)
             }
             _ => runtime::revert(Error::UnknownApiCommand),
         }

--- a/bridge/contract/src/error.rs
+++ b/bridge/contract/src/error.rs
@@ -17,6 +17,7 @@ pub enum Error {
     InvalidArgument4 = 26,             // 65562
     InvalidArgument5 = 27,             // 65563
     UnsupportedNumberOfArguments = 28, // 65564
+    PacketSliceError = 100,            // 65636
     TestError = 999,
 }
 

--- a/bridge/contract/src/main.rs
+++ b/bridge/contract/src/main.rs
@@ -8,13 +8,15 @@ mod error;
 use crate::api::Api;
 use crate::error::Error;
 use casperlabs_contract::{
-    contract_api::{runtime, storage},
-    unwrap_or_revert::UnwrapOrRevert,
+    contract_api::{runtime, storage}
 };
-use casperlabs_types::{ApiError, ContractRef, Key, URef, U512};
+use casperlabs_types::{Key, URef, ApiError};
 use hex;
 use obi::{OBIDecode, OBIEncode};
 use tiny_keccak::{Hasher, Keccak};
+
+#[macro_use]
+extern crate alloc;
 
 pub const INIT_FLAG_KEY: [u8; 32] = [1u8; 32];
 
@@ -55,10 +57,22 @@ impl Req {
 }
 
 #[no_mangle]
+#[allow(unreachable_patterns)]
 pub extern "C" fn call() {
+    runtime::print(&"____________ session main call _____________");
     match Api::from_args() {
-        Api::RELAY_AND_VERIFY(proof) => {
-            let bp = MyPacket::try_from_slice(&proof).unwrap();
+        Api::RelayAndVerify(proof) => {
+            let bp = match MyPacket::try_from_slice(&proof){
+                Ok(bp) => bp,
+                Err(e) => {
+                    runtime::print(&"_____ session main call relay & verify _____");
+                    runtime::print(&format!("arg 1; proof: {:?}", proof));
+                    runtime::print(&format!("proof length = {}", proof.len()));
+                    let text = format!("MyPacket::try_from_slice(&proof) error: {:?}", e);
+                    runtime::print(&text);
+                    runtime::revert(ApiError::User(Error::PacketSliceError as u16))
+                }
+            };
 
             let value_ref: URef = storage::new_uref(proof);
             let value_key: Key = value_ref.into();
@@ -68,16 +82,17 @@ pub extern "C" fn call() {
     }
 }
 
-#[no_mangle]
-pub extern "C" fn my_contract() {
-    match Api::from_args() {
-        Api::RELAY_AND_VERIFY(proof) => {
-            let bp = MyPacket::try_from_slice(&proof).unwrap();
-
-            let value_ref: URef = storage::new_uref(proof);
-            let value_key: Key = value_ref.into();
-            runtime::put_key(&hex::encode(bp.req.get_hash()), value_key);
-        }
-        _ => runtime::revert(Error::UnknownBridgeCallCommand),
-    }
-}
+// #[no_mangle]
+// #[allow(unreachable_patterns)]
+// pub extern "C" fn my_contract() {
+//     match Api::from_args() {
+//         Api::RelayAndVerify(proof) => {
+//             let bp = MyPacket::try_from_slice(&proof).unwrap();
+//
+//             let value_ref: URef = storage::new_uref(proof);
+//             let value_key: Key = value_ref.into();
+//             runtime::put_key(&hex::encode(bp.req.get_hash()), value_key);
+//         }
+//         _ => runtime::revert(Error::UnknownBridgeCallCommand),
+//     }
+// }

--- a/bridge/tests/Cargo.toml
+++ b/bridge/tests/Cargo.toml
@@ -12,9 +12,9 @@ obi = { version = "0.0.1" }
 tiny-keccak = { version = "2.0", features = ["keccak"] }
 
 [dev-dependencies]
-casperlabs-contract = "0.5.0"
-casperlabs-types = "0.5.0"
-casperlabs-engine-test-support = "0.7.0"
+casperlabs-contract = "=0.5.0"
+casperlabs-types = "=0.5.0"
+casperlabs-engine-test-support = "=0.7.0"
 
 [[bin]]
 name = "integration-tests"

--- a/bridge/tests/src/integration_tests.rs
+++ b/bridge/tests/src/integration_tests.rs
@@ -1,4 +1,3 @@
-use hex;
 use obi::*;
 use tiny_keccak::{Hasher, Keccak};
 
@@ -80,17 +79,10 @@ mod tests {
         let key = hex::encode(&mock_packet.req.get_hash());
         let value = hex::decode("0000000966726f6e745f656e6400000000000000010000000f00000003425443000000003b9aca0000000000000000040000000000000002").unwrap();
 
-        println!("{:?}", mock_packet.req.get_hash());
-        println!("{:?}", hex::encode(mock_packet.req.try_to_vec().unwrap()));
+        println!("________________ test setup ________________");
+        println!("mock_packet hash: {:?}", mock_packet.req.get_hash());
+        println!("mock_packet: {:?}", hex::encode(mock_packet.req.try_to_vec().unwrap()));
 
-        // assert_eq!(
-        //     hex::encode(&mock_packet.req.get_hash()),
-        //     String::from("0xaa")
-        // );
-
-        // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
-        // relative to the current working dir (e.g. 'wasm/contract.wasm') can also be used, as can
-        // absolute paths.
         let session_code = Code::from("contract.wasm");
         let session_args = ("relay_and_verify", value.clone());
         let session = SessionBuilder::new(session_code, session_args)
@@ -98,7 +90,10 @@ mod tests {
             .with_authorization_keys(&[MY_ACCOUNT])
             .build();
 
-        let result_of_query: Result<Value, Error> = context.run(session).query(MY_ACCOUNT, &[&key]);
+        println!("_____________ executing contract ___________");
+        let context = context.run(session);
+
+        let result_of_query: Result<Value, Error> = context.query(MY_ACCOUNT, &[&key]);
 
         let returned_value = result_of_query.expect("should be a value");
 


### PR DESCRIPTION
This PR contains a rough debugging triage session for the bridge contract. 

The error appears to be here: https://github.com/prin-r/casperlab_example_contract/blob/master/bridge/contract/src/main.rs#L61

The error raised is: `error: Custom { kind: InvalidInput, error: "Unexpected length of input" }`
